### PR TITLE
added tutorials section to contents

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -70,6 +70,19 @@ Table of Contents
    Logging
    LogFormat
    Glossary
+   
+Tutorials
+=========
+
+.. toctree::
+   :maxdepth: 1
+
+   CachingCookbook
+   Django_and_nginx
+   dreamhost
+   heroku_python
+   heroku_ruby
+
 
 uWSGI Subsystems
 ================


### PR DESCRIPTION
I noticed that the Tutorials were not appearing in the contents, so I have added them to index.rst.
