### PR TITLE
Fix regex

### DIFF
--- a/PHP.rst
+++ b/PHP.rst
@@ -64,7 +64,7 @@ If you have simple apps (based on file extensions) you can use something like th
 
 .. code-block:: nginx
 
-    location ~ .php$ {
+    location ~ \.php$ {
         root /your_document_root;
         include uwsgi_params;
         uwsgi_modifier1 14;
@@ -75,7 +75,7 @@ You might want to check for all of URIs containing the string ``.php``:
 
 .. code-block:: nginx
 
-    location ~ .php {
+    location ~ \.php {
         root /your_document_root;
         include uwsgi_params;
         uwsgi_modifier1 14;


### PR DESCRIPTION
~ in nginx matches a regex, and just a dot `.` in regex matches any single character. To match a the dot we need to escape it like `\.`
