### PR TITLE
Remove duplicated entry in table of contents

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -63,7 +63,6 @@ Table of Contents
    Configuration
    FallbackConfig
    ConfigLogic
-   ParsingOrder
    Options
    CustomOptions
    ParsingOrder


### PR DESCRIPTION
There were two same ParsingOrder entry in the table of contents
