### PR TITLE
fix typo "django.core.handlers.wsgi.WSGIHandler()" -> "django.core.handlers.wsgi:WSGIHandler()"

### DIFF
--- a/WSGIquickstart.rst
+++ b/WSGIquickstart.rst
@@ -176,7 +176,7 @@ using an old (<1.4) django version. In such a case you need a little bit more co
 
 .. code-block:: sh
 
-   uwsgi --socket 127.0.0.1:3031 --chdir /home/foobar/myproject/ --pythonpath .. --env DJANGO_SETTINGS_MODULE=myproject.settings --module "django.core.handlers.wsgi.WSGIHandler()" --processes 4 --threads 2 --stats 127.0.0.1:9191
+   uwsgi --socket 127.0.0.1:3031 --chdir /home/foobar/myproject/ --pythonpath .. --env DJANGO_SETTINGS_MODULE=myproject.settings --module "django.core.handlers.wsgi:WSGIHandler()" --processes 4 --threads 2 --stats 127.0.0.1:9191
 
 ARGH !!! what the hell is this ???
 


### PR DESCRIPTION
fix typo "django.core.handlers.wsgi.WSGIHandler()" -> "django.core.handlers.wsgi:WSGIHandler()"
