### PR TITLE
Update SystemD.rst, adding KillSignal to service unit

### DIFF
--- a/SystemD.rst
+++ b/SystemD.rst
@@ -25,6 +25,7 @@ Create a systemd service file (you can save it as /etc/systemd/system/emperor.uw
    [Service]
    ExecStart=/root/uwsgi/uwsgi --ini /etc/uwsgi/emperor.ini
    Restart=always
+   KillSignal=SIGQUIT
    Type=notify
    StandardError=syslog
    NotifyAccess=main


### PR DESCRIPTION
Without this systemctl stop emperor.uwsgi.service with uwsgi 1.9/2.0 was
taking an age for me. This change ensures systemd sends SIGQUIT and not
SIGTERM as recommended in:
https://uwsgi-docs.readthedocs.org/en/latest/ThingsToKnow.html
