### PR TITLE
Fix single colon in `code-block`

### DIFF
--- a/Lua.rst
+++ b/Lua.rst
@@ -60,7 +60,7 @@ will build a binary with luajit
 
 If you do not want to rely on the pkg-config tool you can manually specify the includes and library directories as well as the lib name with the following environment vars:
 
-.. code-block: sh
+.. code-block:: sh
 
    UWSGICONFIG_LUAINC=<directory>
    UWSGICONFIG_LUALIBPATH=<directory>

--- a/Options.rst
+++ b/Options.rst
@@ -137,7 +137,7 @@ Map sockets to specific workers.
 
 As you can bind a uWSGI instance to multiple sockets, you can use this option to map specific workers to specific sockets to implement a sort of in-process Quality of Service scheme.
 
-.. code-block: ini
+.. code-block:: ini
 
    [uwsgi]
    socket = /tmp/uwsgi0.sock

--- a/_options/optdefs.py
+++ b/_options/optdefs.py
@@ -29,7 +29,7 @@ def core_options():
         s.o("map-socket", [str], "map sockets to specific workers", help="""
         As you can bind a uWSGI instance to multiple sockets, you can use this option to map specific workers to specific sockets to implement a sort of in-process Quality of Service scheme.
 
-        .. code-block: ini
+        .. code-block:: ini
 
            [uwsgi]
            socket = /tmp/uwsgi0.sock


### PR DESCRIPTION
Code examples are not rendered by github and readthedocs when single
colon is used.

That should close #173
