### PR TITLE
Update Flask and Django examples to use http

### DIFF
--- a/WSGIquickstart.rst
+++ b/WSGIquickstart.rst
@@ -169,7 +169,7 @@ We suppose the Django project is in ``/home/foobar/myproject``:
 
 .. code-block:: sh
 
-   uwsgi --socket 127.0.0.1:3031 --chdir /home/foobar/myproject/ --wsgi-file myproject/wsgi.py --master --processes 4 --threads 2 --stats 127.0.0.1:9191
+   uwsgi --http 127.0.0.1:3031 --chdir /home/foobar/myproject/ --wsgi-file myproject/wsgi.py --master --processes 4 --threads 2 --stats 127.0.0.1:9191
 
 (with ``--chdir`` we move to a specific directory). In Django this is required to correctly load modules.
 
@@ -178,7 +178,7 @@ using an old (< 1.4) version of Django. In such a case you need a little bit mor
 
 .. code-block:: sh
 
-   uwsgi --socket 127.0.0.1:3031 --chdir /home/foobar/myproject/ --pythonpath .. --env DJANGO_SETTINGS_MODULE=myproject.settings --module "django.core.handlers.wsgi:WSGIHandler()" --processes 4 --threads 2 --stats 127.0.0.1:9191
+   uwsgi --http 127.0.0.1:3031 --chdir /home/foobar/myproject/ --pythonpath .. --env DJANGO_SETTINGS_MODULE=myproject.settings --module "django.core.handlers.wsgi:WSGIHandler()" --processes 4 --threads 2 --stats 127.0.0.1:9191
 
 Argh! What the hell is this?! Yes, you're right, you're right... dealing with such long command lines is unpractical, foolish and error-prone.
 Never fear! uWSGI supports various configuration styles. In this quickstart we will use .ini files.
@@ -186,7 +186,7 @@ Never fear! uWSGI supports various configuration styles. In this quickstart we w
 .. code-block:: ini
 
    [uwsgi]
-   socket = 127.0.0.1:3031
+   http = 127.0.0.1:3031
    chdir = /home/foobar/myproject/
    pythonpath = ..
    env = DJANGO_SETTINGS_MODULE=myproject.settings
@@ -229,7 +229,7 @@ We still continue to use the 4 processes/2 threads and the uwsgi socket as the b
 
 .. code-block:: sh
 
-   uwsgi --socket 127.0.0.1:3031 --wsgi-file myflaskapp.py --callable app --processes 4 --threads 2 --stats 127.0.0.1:9191
+   uwsgi --http 127.0.0.1:3031 --wsgi-file myflaskapp.py --callable app --processes 4 --threads 2 --stats 127.0.0.1:9191
 
 (the only addition is the ``--callable`` option).
 


### PR DESCRIPTION
The Flask and Django examples don't work because the --socket option is used instead of the --http option.
