### PR TITLE
Fix mod_proxy_uwsgi docs

### DIFF
--- a/Apache.rst
+++ b/Apache.rst
@@ -94,7 +94,7 @@ Starting from Apache 2.4.9, support for Unix sockets has been added. The syntax 
 
 .. parsed-literal::
 
-   ProxyPass / unix:/tmp/uwsgi.sock|uwsgi:
+   ProxyPass / unix:/tmp/uwsgi.sock|uwsgi://
 
 mod_Ruwsgi
 ----------


### PR DESCRIPTION
The ProxyPass directive needs to end with a double slash.
