### PR TITLE
Management: use systemd on Debian

### DIFF
--- a/Management.rst
+++ b/Management.rst
@@ -23,7 +23,7 @@ On modern systems the following should hold true. On "classic" operating systems
 System         Method
 ============== =========
 Ubuntu         :doc:`Upstart` (the official ``uwsgi`` package, available since Ubuntu 12.04 provides an init.d based solution. Read the README.)
-Debian         :doc:`Upstart`
+Debian         :doc:`Systemd`
 Arch Linux     :doc:`Systemd`
 Fedora         :doc:`Systemd`
 OSX            launchd


### PR DESCRIPTION
Howdy there!

It doesn't really make sense to recommend using upstart on Debian; unlike Ubuntu, Debian has never used upstart by default, and we actually have systemd as the default in Debian stable now. Recommending systemd should be better.