### PR TITLE
Add more detail about auto chunk, more info for ELB and Content-Length.

### DIFF
--- a/HTTP.rst
+++ b/HTTP.rst
@@ -87,11 +87,18 @@ HTTP Keep-Alive
 ---------------
 
 If your backends set the correct HTTP headers, you can use the
-``http-keepalive`` option.  Your backends will need to set a valid
-``Content-Length`` in each response or use chunked encoding. Simply setting
-"Connection: close" is *not enough*.  Also remember to set "Connection:
-Keep-Alive" in your response. You can automate that using the ``add-header
-"Connection: Keep-Alive"`` option.
+``http-keepalive`` option.  Either your backends will need to set a valid
+``Content-Length`` in each response, or you can use chunked encoding with
+``http-auto-chunked``. Simply setting "Connection: close" is *not enough*.
+Also remember to set "Connection: Keep-Alive" in your response. You can
+automate that using the ``add-header "Connection: Keep-Alive"`` option.
+
+HTTP auto gzip
+-------------
+
+With the ``http-auto-gzip`` option, uWSGI can automatically gzip content if the
+uWSGI-encoding header is set to gzip while ``Content-Length`` and
+``Content-Encoding`` are not set.
 
 Can I use uWSGI's HTTP capabilities in production?
 --------------------------------------------------
@@ -105,5 +112,12 @@ on a CDN, using uWSGI's HTTP capabilities you can definitely avoid configuring
 a full webserver.
 
 .. note:: If you use Amazon's ELB (Elastic Load Balancer) in HTTP mode in
-   front of uWSGI in HTTP mode, a valid ``Content-Length`` *must be set* by the
-   backend.
+   front of uWSGI in HTTP mode, either a valid ``Content-Length`` *must be set*
+   by the backend, or chunked encoding must be used, e.g., with
+   ``http-auto-chunked``. The ELB "health test" may still fail in HTTP mode
+   regardless, in which case a TCP health test can be used instead.
+
+.. note:: In particular, the Django backend does not set ``Content-Length`` by
+   default, while most others do. If running behind ELB, either use chunked
+   encoding as above, or force Django to specify ``Content-Length`` with the
+   "Conditional GET" Django middleware.


### PR DESCRIPTION
I recently set up Elastic Load Balancing on AWS with each instance having uWSGI+Django.  Despite reading and re-reading the uWSGI docs over and over again (and the Django docs), I could not make the connection between uWSGI, `Content-Length`, and Django failing to set it by default!  Eventually, I got to #django on IRC and @funkybob explained what was required, and I got it working.  I'm hoping these minor changes to the docs will help someone else avoid that confusion. (side note: I did some load tests and even with only two or three t2.micro instances in this ELB setup, performance is way more than I need 👏)

I also added a section for ``http-auto-gzip`` which is mostly copied from the 1.9 release notes page. I figure the intention was to get around to putting that in here eventually. I did not do the websocket stuff because I don't know enough about it.