### PR TITLE
Removed 'master=true' option since it's superfluous when using Emperor

### DIFF
--- a/Emperor.rst
+++ b/Emperor.rst
@@ -43,7 +43,6 @@ skipped)
 
   [uwsgi]
   chdir = /opt/apps/%n
-  master = true
   threads = 20
   socket = /tmp/sockets/%n.sock
   env = DJANGO_SETTINGS_MODULE=%n.settings


### PR DESCRIPTION
Details: http://stackoverflow.com/questions/15055002/uwsgi-master-with-emperor-spawns-two-emperors/15856871#15856871