### PR TITLE
Move obsoleted webservers to the bottom

### DIFF
--- a/WebServers.rst
+++ b/WebServers.rst
@@ -3,16 +3,6 @@ Web server integration
 
 uWSGI supports several methods of integrating with web servers. It is also capable of serving HTTP requests by itself.
 
-Cherokee
---------------
-
-.. seealso:: :doc:`Cherokee`
-
-The Cherokee webserver officially supports uWSGI.
-Cherokee is fast and lightweight, has a beautiful admin interface and a great community.
-Their support for uWSGI has been awesome since the beginning and we recommend its use in most situations.
-The userbase of the Cherokee uWSGI handler is probably the biggest of all. The Cherokee uWSGI handler is commercially supported by Unbit.
-
 Nginx
 ------------
 
@@ -21,6 +11,7 @@ Nginx
 The uWSGI module is included in the official Nginx distribution since version 0.8.40. A version supporting Nginx 0.7.x  is maintained in the uWSGI package.
 
 This is a stable handler commercially supported by Unbit.
+
 
 Apache
 ------
@@ -37,21 +28,8 @@ Since uWSGI 0.9.6-dev a second Apache2 module called `mod_Ruwsgi` is included. I
 During the 1.2 development cycle, another module called `mod_proxy_uwsgi` has been added. In the near future this should be the best choice for Apache based deployments.
 
 
-
-Mongrel2
---------
-
-.. seealso:: :doc:`Mongrel2`
-
-
-Support for the `Mongrel2 Project <http://mongrel2.org/>`_ has been available since 0.9.8-dev via the :doc:`ZeroMQ` protocol plugin.
-
-In our tests Mongrel2 survived practically all of the loads we sent.
-
-Very good and solid project. Try it :) 
-
-Lighttpd
---------
+Lighttpd (Experimental)
+-----------------------
 
 This module is the latest developed, but its inclusion in the official Lighttpd distribution has been rejected, as the main author considers the :doc:`uwsgi protocol<Protocol>` a "reinventing the wheel" technology while suggesting a FastCGI approach. We respect this position. The module will continue to reside in the uWSGI source tree, but it is currently unmaintained.
 
@@ -62,6 +40,7 @@ Twisted
 -------
 
 This is a "commodity" handler, useful mainly for testing applications without installing a full web server. If you want to develop an uWSGI server, look at this module. :doc:`Twisted`.
+
 
 Tomcat
 ------
@@ -76,3 +55,27 @@ CGI
 ---
 
 The CGI handlers are for "lazy" installations. Their use in production environments is discouraged.
+
+
+Cherokee (Obsolete)
+-------------------
+
+.. seealso:: :doc:`Cherokee`
+
+The Cherokee webserver officially supports uWSGI.
+Cherokee is fast and lightweight, has a beautiful admin interface and a great community.
+Their support for uWSGI has been awesome since the beginning and we recommend its use in most situations.
+The userbase of the Cherokee uWSGI handler is probably the biggest of all. The Cherokee uWSGI handler is commercially supported by Unbit.
+
+
+Mongrel2 (Obsolete)
+--------
+
+.. seealso:: :doc:`Mongrel2`
+
+
+Support for the `Mongrel2 Project <http://mongrel2.org/>`_ has been available since 0.9.8-dev via the :doc:`ZeroMQ` protocol plugin.
+
+In our tests Mongrel2 survived practically all of the loads we sent.
+
+Very good and solid project. Try it :) 


### PR DESCRIPTION
Mongrel2 and Cherokee looks quite dead to me. Also mark lighttpd
as experimental.