### PR TITLE
Document that tuntap router and xattr plugins are linux only

### DIFF
--- a/InternalRouting.rst
+++ b/InternalRouting.rst
@@ -944,3 +944,30 @@ Clear the response headers, setting a new HTTP status code, useful for resetting
 ^^^^^^^^^^^^^^^^
 
 Alias for clearheaders
+
+``xattr``
+^^^^^^^^^
+
+Plugin: ``xattr``
+
+The xattr plugin allows you to reference files extended attributes in the internal routing subsystem:
+
+.. code-block:: ini
+
+   [uwsgi]
+   ...
+   route-run = addvar:MYATTR=user.uwsgi.foo.bar
+   route-run = log:The attribute is ${xattr[/tmp/foo:MYATTR]}
+
+
+or (variant with 2 vars)
+
+.. code-block:: ini
+
+   [uwsgi]
+   ...
+   route-run = addvar:MYFILE=/tmp/foo
+   route-run = addvar:MYATTR=user.uwsgi.foo.bar
+   route-run = log:The attribute is ${xattr2[MYFILE:MYATTR]}
+
+It work only on linux platforms.

--- a/TunTapRouter.rst
+++ b/TunTapRouter.rst
@@ -1,7 +1,7 @@
 The TunTap Router
 =================
 
-The TunTap router is an ad-hoc solution for giving network connectivity to Linux processes running in a dedicated network namespace (well obviously it has other uses, but very probably this is the most interesting one, and the one for which it was developed)
+The TunTap router is an ad-hoc solution for giving network connectivity to Linux processes running in a dedicated network namespace. Well obviously it has other uses, but very probably this is the most interesting one, and the one for which it was developed. Currently it builds only on Linux platforms.
 
 
 The TunTap router is not compiled in by default.


### PR DESCRIPTION
These should fix https://github.com/unbit/uwsgi/issues/695 and https://github.com/unbit/uwsgi/issues/696