### PR TITLE
Replace `pidfile` with `safe-pidfile` in recommended configs

### DIFF
--- a/Management.rst
+++ b/Management.rst
@@ -34,7 +34,7 @@ Solaris        SMF
 Signals for controlling uWSGI
 -----------------------------
 
-You can instruct uWSGI to write the master process PID to a file with the ``pidfile`` option.
+You can instruct uWSGI to write the master process PID to a file with the ``safe-pidfile`` option.
 
 The uWSGI server responds to the following signals.
 

--- a/articles/TheArtOfGracefulReloading.rst
+++ b/articles/TheArtOfGracefulReloading.rst
@@ -581,8 +581,12 @@ files (like pidfiles or logs) to different paths:
 
     [uwsgi]
     logto = /var/log/%n.log
-    pidfile = /var/run/%n.pid
+    safe-pidfile = /var/run/%n.pid
     ; and so on ...
+
+The ``safe-pidfile`` option works similar to ``pidfile`` but performs the write
+a little later in the loading process. This avoids overwriting the value when
+app loading fails, with the consequent loss of a valid PID number.
 
 Dealing with ultra-lazy apps (like Django)
 ******************************************

--- a/tutorials/Django_and_nginx.rst
+++ b/tutorials/Django_and_nginx.rst
@@ -538,7 +538,7 @@ look at for a deployment in production include (listed here with example
 settings)::
 
     env = DJANGO_SETTINGS_MODULE=mysite.settings # set an environment variable
-    pidfile = /tmp/project-master.pid # create a pidfile
+    safe-pidfile = /tmp/project-master.pid # create a pidfile
     harakiri = 20 # respawn processes taking more than 20 seconds
     limit-as = 128 # limit the project to 128 MB
     max-requests = 5000 # respawn processes after serving 5000 requests


### PR DESCRIPTION
Closes #281