### PR TITLE
More documentation for on demand vassals

### DIFF
--- a/Emperor.rst
+++ b/Emperor.rst
@@ -29,6 +29,7 @@ Multiple sources of configuration may be monitored by specifying ``--emperor`` m
 
   ImperialMonitors
   EmperorProtocol
+  OnDemandVassals
 
 Special configuration variables
 -------------------------------
@@ -140,13 +141,6 @@ root-capabilities needed to apply the tyrant mode
    emperor = /tmp
    emperor-tyrant = true
    cap = setgid,setuid
-
-On demand vassals (socket activation)
--------------------------------------
-
-Inspired by the venerable xinetd/inetd approach, you can spawn your vassals
-only after the first connection to a specific socket. This feature is available
-as of 1.9.1. Check the changelog for more information: :doc:`Changelog-1.9.1`
 
 
 Loyalty

--- a/ImperialMonitors.rst
+++ b/ImperialMonitors.rst
@@ -76,23 +76,29 @@ run them.
 ``glob://`` -- monitor a shell pattern
 --------------------------------------
 
-``glob://`` is similar to ``dir://``, but a glob expression must be specified::
+``glob://`` is similar to ``dir://``, but a glob expression must be specified:
 
-  uwsgi --emperor "/etc/vassals/domains/*/conf/uwsgi.xml"
-  uwsgi --emperor "/etc/vassals/*.ini"
+.. code-block:: sh
+
+ uwsgi --emperor "/etc/vassals/domains/*/conf/uwsgi.xml"
+ uwsgi --emperor "/etc/vassals/*.ini"
 
 .. note:: Remember to quote the pattern, otherwise your shell will most likely
    interpret it and expand it at invocation time, which is not what you want.
 
 As the Emperor can search for configuration files in subdirectory hierarchies,
-you could have a structure like this::
+you could have a structure like this:
+
+.. code-block:: sh
 
   /opt/apps/app1/app1.xml
   /opt/apps/app1/...all the app files...
   /opt/apps/app2/app2.ini
   /opt/apps/app2/...all the app files...
 
-and run uWSGI with::
+and run uWSGI with:
+
+.. code-block:: sh
 
   uwsgi --emperor /opt/apps/app*/app*.*
 
@@ -101,7 +107,7 @@ and run uWSGI with::
 ------------------------------------------------------
 
 You can specify a query to run against a PostgreSQL database. Its result must
-be a list of 3 to 5 fields defining a vassal:
+be a list of 3 to 6 fields defining a vassal:
 
 1. The instance name, including a valid uWSGI config file extension. (Such as
    ``django-001.ini``)
@@ -111,6 +117,9 @@ be a list of 3 to 5 fields defining a vassal:
    (seconds since the epoch).
 4. The UID of the vassal instance. Required in :ref:`Tyrant` mode only.
 5. The GID of the vassal instance. Required in :ref:`Tyrant` mode only.
+6. Socket for on demand vassal activation. If specified, vassal will be run
+   in on demand mode. If ommited or empty, vassal will be run normally. Go to
+   :doc:`OnDemandVassals` for more information.
 
 .. code-block:: sh
 
@@ -139,6 +148,9 @@ more fields are required.
 * ``ts`` (date) is the timestamp of the config (Note: MongoDB internally stores the timestamp in milliseconds.)
 * ``uid`` (number) is the UID to run the vassal as. Required in :ref:`Tyrant` mode only.
 * ``gid`` (number) is the GID to run the vassal as. Required in :ref:`Tyrant` mode only.
+* ``socket`` (string) Socket for on demand vassal activation. If specified,
+  vassal will be run in on demand mode. If ommited or empty, vassal will be run
+  normally. Go to :doc:`OnDemandVassals` for more information.
 
 ``amqp://`` -- Use an AMQP compliant message queue to announce events
 ---------------------------------------------------------------------
@@ -227,13 +239,16 @@ The Emperor binds itself to a ZeroMQ PULL socket, ready to receive commands.
    uwsgi --plugin emperor_zeromq --emperor zmq://tcp://127.0.0.1:5252
 
 Each command is a multipart message sent over a PUSH zmq socket.  A command is
-composed by at least 2 parts: ``command`` and ``name`` ``command`` is the
-action to execute, while ``name`` is the name of the vassal.  3 optional parts
+composed by at least 2 parts: ``command`` and ``name``. ``command`` is the
+action to execute, while ``name`` is the name of the vassal. 4 optional parts
 can be specified.
 
 * ``config`` (a string containing the vassal config)
 * ``uid`` (the user id to drop priviliges to in case of tyrant mode)
 * ``gid`` (the group id to drop priviliges to in case of tyrant mode)
+* ``socket`` (socket for on demand vassal activation. If specified,
+  vassal will be run in on demand mode. If ommited or empty, vassal will be run
+  normally. Go to :doc:`OnDemandVassals` for more information)
 
 There are 2 kind of commands (for now):
 

--- a/ImperialMonitors.rst
+++ b/ImperialMonitors.rst
@@ -141,7 +141,8 @@ be a list of 3 to 6 fields defining a vassal:
 This will scan all of the documents in the ``emperor.vassals`` collection
 having the field ``enabled`` set to 1.  An Emperor-compliant document must
 define three fields: ``name``, ``config`` and ``ts``. In :ref:`Tyrant` mode, 2
-more fields are required.
+more fields are required. There is also optional ``socket`` field for on
+demand vassal mode.
 
 * ``name`` (string) is the name of the vassal (remember to give it a valid extension, like .ini)
 * ``config`` (multiline string) is the vassal config in the format described by the ``name``'s extension.

--- a/OnDemandVassals.rst
+++ b/OnDemandVassals.rst
@@ -1,0 +1,107 @@
+On demand vassals (socket activation)
+=====================================
+
+Inspired by the venerable xinetd/inetd approach, you can spawn your vassals
+only after the first connection to a specific socket. This feature is available
+as of 1.9.1. Combined with –idle/–die-on-idle options, you can have truly
+on-demand applications.
+
+When on demand is active for particular vassal, emperor won't spawn it on start
+(or when it's config changes), but it will rather create socket for that
+vassal and monitor if anything connects to it.
+
+At the first connection, the vassal is spawned and the socket passed as the file
+descriptor 0. File descriptor 0 is always checked by uWSGI so you do not need to
+specify a --socket option in the vassal file. This works automagically for uwsgi
+sockets, if you use other protocols (like http or fastcgi) you have to
+specify it with the --protocol option
+
+.. important::
+
+  If you will define in your vassal config same socket as used by emperor for
+  on demand action, vassal will override that socket file. That could lead to
+  unexpected behaviour, for example on demand activation of that vassal will
+  work only once.
+
+On demand vassals with filesystem-based imperial monitors
+---------------------------------------------------------
+
+For filesystem-based imperial monitors, such as ``dir://`` or ``glob://``,
+defining on demand vassals involves defining one of three additional settings
+for your emperor:
+
+--emperor-on-demand-extension <ext>
+***********************************
+
+this will instruct the Emperor to check for a file named <vassal>+<ext>, if the
+file is available it will be read and its content used as the socket to wait
+for:
+
+.. code-block:: sh
+
+   uwsgi --emperor /etc/uwsgi/vassals --emperor-on-demand-extension .socket
+
+supposing a myapp.ini file in /etc/uwsgi/vassals, a /etc/uwsgi/vassals/myapp.ini.socket
+will be searched for (and its content used as the socket name). Note that
+myapp.ini.socket isn't a socket! This file only contains path for actual socket
+(tcp or unix).
+
+--emperor-on-demand-directory <dir>
+***********************************
+
+This is a less-versatile approach supporting only UNIX sockets. Basically the
+name (without extension and path) of the vassal is appended to the specified
+directory + the .socket extension and used as the on-demand socket:
+
+.. code-block:: sh
+
+   uwsgi --emperor /etc/uwsgi/vassals --emperor-on-demand-directory /var/tmp
+
+using the previous example, the socket /var/tmp/myapp.socket will be
+automatically bound.
+
+--emperor-on-demand-exec <cmd>
+******************************
+
+This is most flexible solution for defining socket for on demand action and
+(very probably) you will use it in very big deployments. Every time a new vassal
+is added the supplied command is run passing full path to vassal config file as
+the first argument. The STDOUT of the command is used as the socket name.
+
+Using on demand vassals with other imperial monitors
+----------------------------------------------------
+
+For some imperial monitors, such as ``pg://``, ``mongodb://``, ``zmq://`` socket
+for on demand activation is returned by imperial monitor by itself. For example
+for ``pg://`` if executed on database query returns more than 5 fields, 6th
+field will be used as socket for on demand activation. Check
+:doc:`ImperialMonitors` for more information.
+
+For some imperial monitors, such as ``amqp://``, socket activation is not
+possible yet.
+
+Combining on demand vassals with ``--idle`` and ``--die-on-idle``
+-----------------------------------------------------------------
+
+For truly on demand applications, you can add to each vassal ``--idle`` and
+``--die-on-idle`` options. This will allow suspend or completely turn off
+applications that are no longer requested. ``--idle`` without
+``--die-on-idle`` will work pretty much like without emperor, but adding
+``--die-on-idle`` will give you superpower for completely shutting down
+applications and returning back to on-demand mode.
+
+Emperor will simply put vassal back to on-demand mode when it dies gracefully
+and turn it back on when there are any requests waiting or socket.
+
+.. important::
+
+  As mentioned before, you should **never** put in your vassal config file
+  socket that was passed to emperor for on-demand mode. For unix sockets,
+  file path that socket lives on will be rewritten with new socket, but old
+  socket will be still connected to your emperor. Emperor will listen for
+  connections on that old socket, but all requests will arrive to new one.
+  That means, if your vassal will be shut down because of idle state, it will
+  be **never** put back on (emperor won't receive any connections for
+  on-demand socket).
+
+  For tcp socket, that can cause each request to be handled **twice**.


### PR DESCRIPTION
Moved existing documentation for on demand vassals from emperor page to separate one. Copied and improved description of `--emperor-on-demand` options from changelog to newly created page, added usage for on demand vassals in other imperial monitors (non-filesystem-based ones), added description about using on demand vassals with `--idle` and `--die-on-idle`, added important warning about sockets for on demand vassals.