### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/Changelog-1.9.1.rst
+++ b/Changelog-1.9.1.rst
@@ -134,7 +134,7 @@ New routing conditions
 
 New routing conditions have been added (equal,startswith,endswith,regexp) check the updated docs:
 
-http://uwsgi-docs.readthedocs.org/en/latest/InternalRouting.html#the-internal-routing-table
+https://uwsgi-docs.readthedocs.io/en/latest/InternalRouting.html#the-internal-routing-table
 
 The 'V' magic var
 *****************

--- a/Changelog-1.9.15.rst
+++ b/Changelog-1.9.15.rst
@@ -247,7 +247,7 @@ A new python loader (--pecan) has been added for the pecan WSGI framework
 
 http://pecanpy.org/
 
-https://uwsgi-docs.readthedocs.org/en/latest/Python.html#pecan-support
+https://uwsgi-docs.readthedocs.io/en/latest/Python.html#pecan-support
 
 UWSGI_REMOVE_INCLUDES
 *********************

--- a/Changelog-1.9.16.rst
+++ b/Changelog-1.9.16.rst
@@ -129,7 +129,7 @@ Author: Łukasz Mierzwa
 
 This new check allows control of dynamic process spawning based on the RSS usage:
 
-http://uwsgi-docs.readthedocs.org/en/latest/Cheaper.html#setting-memory-limits
+https://uwsgi-docs.readthedocs.io/en/latest/Cheaper.html#setting-memory-limits
 
 Log encoders
 ^^^^^^^^^^^^

--- a/Changelog-1.9.18.rst
+++ b/Changelog-1.9.18.rst
@@ -235,7 +235,7 @@ It could be hard to understand why an application server should check for mountp
 
 In the same way understanding how writing filesystem in userspace was silly few years ago.
 
-So, check the article about managing Fuse filesystem with uWSGI: http://uwsgi-docs.readthedocs.org/en/latest/tutorials/ReliableFuse.html
+So, check the article about managing Fuse filesystem with uWSGI: https://uwsgi-docs.readthedocs.io/en/latest/tutorials/ReliableFuse.html
 
 Preliminary libffi plugin
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/Changelog-1.9.20.rst
+++ b/Changelog-1.9.20.rst
@@ -51,7 +51,7 @@ Simple math in configuration files
 
 As seen before, we have removed matheval support in favor of a simplified interface:
 
-http://uwsgi-docs.readthedocs.org/en/latest/Configuration.html#placeholders-math-from-uwsgi-1-9-20-dev
+https://uwsgi-docs.readthedocs.io/en/latest/Configuration.html#placeholders-math-from-uwsgi-1-9-20-dev
 
 For example, now you can automatically set the number of threads to:
 

--- a/Changelog-1.9.21.rst
+++ b/Changelog-1.9.21.rst
@@ -141,7 +141,7 @@ The chain reloading subsystem has been improved to take in account when a worker
 
 This specific state is announced to the Emperor too.
 
-Check this article for more infos: http://uwsgi-docs.readthedocs.org/en/latest/articles/TheArtOfGracefulReloading.html
+Check this article for more infos: https://uwsgi-docs.readthedocs.io/en/latest/articles/TheArtOfGracefulReloading.html
 
 --after-request-call
 ^^^^^^^^^^^^^^^^^^^^

--- a/Changelog-1.9.7.rst
+++ b/Changelog-1.9.7.rst
@@ -81,7 +81,7 @@ Gzip caching
 
 The cachestore routing function can now directly store items in gzip format.
 
-Check the CachingCookbook: http://uwsgi-docs.readthedocs.org/en/latest/tutorials/CachingCookbook.html
+Check the CachingCookbook: https://uwsgi-docs.readthedocs.io/en/latest/tutorials/CachingCookbook.html
 
 --skip-atexit
 ^^^^^^^^^^^^^

--- a/Changelog-1.9.rst
+++ b/Changelog-1.9.rst
@@ -313,7 +313,7 @@ Emperor ZMQ plugin
 
 A new imperial monitor has been added allowing vassals to be governed over zeromq messages:
 
-http://uwsgi-docs.readthedocs.org/en/latest/ImperialMonitors.html#zmq-zeromq
+https://uwsgi-docs.readthedocs.io/en/latest/ImperialMonitors.html#zmq-zeromq
 
 Total introspection via the stats server
 ****************************************

--- a/Changelog-2.0.4.rst
+++ b/Changelog-2.0.4.rst
@@ -26,7 +26,7 @@ asyncio (also known as 'tulip') is the new infrastructure for writing non-blocki
 
 This (experimental) plugin allows you to use asyncio as the uWSGI loop engine.
 
-Docs: http://uwsgi-docs.readthedocs.org/en/latest/asyncio.html
+Docs: https://uwsgi-docs.readthedocs.io/en/latest/asyncio.html
 
 httprouter advanced timeout management
 **************************************
@@ -59,7 +59,7 @@ support embedded config on FreeBSD
 
 You can now embed configuration files into the binary also on FreeBSD systems: 
 
-http://uwsgi-docs.readthedocs.org/en/latest/Embed.html#step-2-embedding-the-config-file
+https://uwsgi-docs.readthedocs.io/en/latest/Embed.html#step-2-embedding-the-config-file
 
 RPC hook
 ********

--- a/Changelog-2.0.6.rst
+++ b/Changelog-2.0.6.rst
@@ -30,7 +30,7 @@ Support for uploading objects (via PUT) and creating new pools (MKCOL) has been 
 
 Expect WebDAV support in uWSGI 2.1.
 
-Docs have been updated: http://uwsgi-docs.readthedocs.org/en/latest/Rados.html
+Docs have been updated: https://uwsgi-docs.readthedocs.io/en/latest/Rados.html
 
 --if-hostname
 *************
@@ -55,7 +55,7 @@ After literally years of bug reports and corrupted data and other general badnes
 
 On modern Apache2 releases it supports UNIX sockets too.
 
-Updated docs: http://uwsgi-docs.readthedocs.org/en/latest/Apache.html#mod-proxy-uwsgi
+Updated docs: https://uwsgi-docs.readthedocs.io/en/latest/Apache.html#mod-proxy-uwsgi
 
 uwsgi[rsize] routing var
 ************************

--- a/Changelog-2.0.8.rst
+++ b/Changelog-2.0.8.rst
@@ -35,7 +35,7 @@ This custom hook allows you to call actions after each `fork()`.
 fallback to trollius for asyncio plugin
 ***************************************
 
-If you build the asyncio plugin for python2, a fallback to the `trollius <http://trollius.readthedocs.org/>`_ module will be tried.
+If you build the asyncio plugin for python2, a fallback to the `trollius <https://trollius.readthedocs.io/>`_ module will be tried.
 
 This feature has gotten basically zero test coverage, so every report (bug or success alike) is welcome.
 

--- a/Changelog-2.0.9.rst
+++ b/Changelog-2.0.9.rst
@@ -33,14 +33,14 @@ Improved PyPy support for Linux
 
 The PyPy team have started building libpypy-c.so in their official releases. Now using pypy with uWSGI should be way easier:
 
-http://uwsgi-docs.readthedocs.org/en/latest/PyPy.html
+https://uwsgi-docs.readthedocs.io/en/latest/PyPy.html
 
 Fastrouter post-buffering
 *************************
 
 The fastrouter got post-buffering:
 
-http://uwsgi-docs.readthedocs.org/en/latest/Fastrouter.html#post-buffering-mode-uwsgi-2-0-9
+https://uwsgi-docs.readthedocs.io/en/latest/Fastrouter.html#post-buffering-mode-uwsgi-2-0-9
 
 Perl uwsgi::opt
 ***************

--- a/Circus.rst
+++ b/Circus.rst
@@ -1,7 +1,7 @@
 Running uWSGI instances with Circus
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Circus (http://circus.readthedocs.org/en/0.7/) is a process manager written in
+Circus (https://circus.readthedocs.io/en/0.7/) is a process manager written in
 Python. It is very similar to projects like Supervisor, but with several
 additional features.  Although most, if not all, of it's functionalities have a
 counterpart in uWSGI, Circus can be used as a library allowing you to build

--- a/Ring.rst
+++ b/Ring.rst
@@ -107,7 +107,7 @@ We want to add the ``ring-core`` package to our dependencies (it contains a set 
 
    (defproject helloworld "0.1.0-SNAPSHOT"
   :description "My second uWSGI ring app"
-  :url "https://uwsgi-docs.readthedocs.org/en/latest/Ring.html"
+  :url "https://uwsgi-docs.readthedocs.io/en/latest/Ring.html"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.Clojure/Clojure "1.4.0"] [ring/ring-core "1.2.0-beta1"]])

--- a/articles/SerializingAccept.rst
+++ b/articles/SerializingAccept.rst
@@ -456,7 +456,7 @@ I have to admit, I am not a big fan of supervisord. It is a good software
 without doubts, but I consider the Emperor and the --attach-daemon facilities a
 better approach to the deployment problems. In addition to this, if you want to
 have a "scriptable"/"extendable" process supervisor I think Circus
-(http://circus.readthedocs.org/) is a lot more fun and capable (the first thing
+(https://circus.readthedocs.io/) is a lot more fun and capable (the first thing
 I have done after implementing socket activation in the uWSGI Emperor was
 making a pull request [merged, if you care] for the same feature in Circus).
 

--- a/tutorials/ConfiguringFastRouterUsingACPPPlugin.rst
+++ b/tutorials/ConfiguringFastRouterUsingACPPPlugin.rst
@@ -6,7 +6,7 @@ Intro
 
 This tutorial assumes that you are familiar with the usage and purpose of the uwsgi fastrouter and you are facing an edge-case (like "Darth Vader wearing a t-shirt with your face") so you have to use some kind of code-driven "configuration". The fastrouter documentation page recommends `the --fastrouter-use-code-string commandline argument of uwsgi`_ to solve such terribly complicated routing problems by executing your own code/logic for each request to decide which gateway to send it to. The official documentation (at the previous link) shows an example where a python script provides the routing logic and the doc states that you can use any uwsgi-supported language to configure the fastrouter (although my uwsgi-2.0.3 seems to have the code_string feature only in its python and ruby plugins if I'm right...). This tutorial shows you how to write and compile a C++ plugin that contains the routing logic for the fastrouter. This document can also serve a partial/basic C++ plugin tutorial.
 
-.. _the --fastrouter-use-code-string commandline argument of uwsgi: http://uwsgi-docs.readthedocs.org/en/latest/Fastrouter.html#way-5-fastrouter-use-code-string
+.. _the --fastrouter-use-code-string commandline argument of uwsgi: https://uwsgi-docs.readthedocs.io/en/latest/Fastrouter.html#way-5-fastrouter-use-code-string
 
 To make things a bit more complicated I will do the development of this plugin on windows using a cygwin environment. In case of such a simple plugin this involves only 1-2 extra steps compared to building on linux, I will comment the differences. For production I'm using "original" Debian and Ubuntu distros so my examples work there for sure.
 
@@ -225,7 +225,7 @@ The extra argument of the --fastrouter-use-code-string is "251::". This is basic
 
 Note that I've chosen 251 as the modifier of my plugin because based on my research modifier 1 has a lot to do with `The uwsgi Protocol`_ and moreover if you take a look at the plugins/example or plugins/cplusplus example plugins in the uwsgi source dir then you will see that those are using modifier1=250 and 251 seems to be a free id. Note that I've also tried 0 as the modifier1 that is the default modifier1 used by uwsgi and its very first plugin: the python plugin. This seems to work and it seems that this registers our plugin with modifier1=0 by "overriding the python plugin" but I wanted to be polite so I've chosen modifier=251.
 
-.. _The uwsgi Protocol: http://uwsgi-docs.readthedocs.org/en/latest/Protocol.html
+.. _The uwsgi Protocol: https://uwsgi-docs.readthedocs.io/en/latest/Protocol.html
 
 Programming the routing logic in our plugin
 ===========================================
@@ -242,7 +242,7 @@ We started the fastrouter with the "--fastrouter 127.0.0.1:9000 --fastrouter-use
 
 So nginx will route all requests coming to url path /test to the fastrouter by setting UWSGI_FASTROUTER_KEY (basically a "cgi variable") to a user defined string. UWSGI_FASTROUTER_KEY can be anything, you have put something into it that you can use in your plugin to decide where (which gateway) to send the request. In this case I've decided to send the $request_uri to my plugin but you can really put there anything you want. If you don't specify the UWSGI_FASTROUTER_KEY in the nginx config then the fastrouter will use something else instead of it as the fastrouter key (but I think specifying the UWSGI_FASTROUTER_KEY is highly recommended), more on that in the `Notes section of the fastrouter docs`_.
 
-.. _Notes section of the fastrouter docs: http://uwsgi-docs.readthedocs.org/en/latest/Fastrouter.html#notes
+.. _Notes section of the fastrouter docs: https://uwsgi-docs.readthedocs.io/en/latest/Fastrouter.html#notes
 
 With the above fastrouter + nginx config when the fastrouter receives a request from nginx it calls the ``CodeString()`` function of our plugin to ask for the gateway address to use for that request.
 

--- a/tutorials/Django_and_nginx.rst
+++ b/tutorials/Django_and_nginx.rst
@@ -530,7 +530,7 @@ uWSGI
 uWSGI supports multiple ways to configure it. See `uWSGI's documentation`_ and
 `examples`_.
 
-.. _uWSGI's documentation: https://uwsgi-docs.readthedocs.org
+.. _uWSGI's documentation: https://uwsgi-docs.readthedocs.io
 .. _examples: http://projects.unbit.it/uwsgi/wiki/Example
 
 Some uWSGI options have been mentioned in this tutorial; others you ought to


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.