### PR TITLE
Link to HTTPS versions of release downloads

### DIFF
--- a/Download.rst
+++ b/Download.rst
@@ -7,7 +7,7 @@ These are the current versions of uWSGI.
 Release                   Date        Link
 ========================  ==========  ===================================================
 Unstable/Development      \-          https://github.com/unbit/uwsgi/
-Stable/LTS                2016-05-13  http://projects.unbit.it/downloads/uwsgi-2.0.13.1.tar.gz
+Stable/LTS                2016-05-13  https://projects.unbit.it/downloads/uwsgi-2.0.13.1.tar.gz
 DOCS                      \-          https://github.com/unbit/uwsgi-docs/
 ========================  ==========  ===================================================
 


### PR DESCRIPTION
The Stable/LTS release URL was HTTP. I figured it was better to provide the working HTTPS URL as the default.