### PR TITLE
Correction of the cron string example in Cron.rst

### DIFF
--- a/Cron.rst
+++ b/Cron.rst
@@ -77,7 +77,7 @@ For example:
 
    [uwsgi]
    ; every two hours
-   cron = -1 -2 -1 -1 -1 /usr/bin/backup_my_home --recursive
+   cron = 0 -2 -1 -1 -1 /usr/bin/backup_my_home --recursive
 
 Legion crons
 ************
@@ -91,7 +91,7 @@ crons only if it is the Lord of the specified Legion:
    legion = mycluster 225.1.1.1:1717 100 bf-cbc:hello
    legion-node = mycluster 225.1.1.1:1717
    ; every two hours
-   legion-cron = mycluster -1 -2 -1 -1 -1 /usr/bin/backup_my_home --recursive
+   legion-cron = mycluster 0 -2 -1 -1 -1 /usr/bin/backup_my_home --recursive
 
 Unique crons
 ************


### PR DESCRIPTION
It seems like uWSGI cron interface behavior is the same as a crontab in latest versions. 
The "every two hours" in a crontab format: 0 */2 * * *. So these lines should be corrected to:
0, -2, -1, -1, -1