### PR TITLE
No need to specify FreeBSD version

### DIFF
--- a/SupportedPlatforms.rst
+++ b/SupportedPlatforms.rst
@@ -5,7 +5,7 @@ This is the list of officially supported operating systems and platforms.
 
 
 * Linux 2.6/3.x
-* FreeBSD >= 7
+* FreeBSD
 * NetBSD
 * OpenBSD
 * DragonFlyBSD


### PR DESCRIPTION
FreeBSD 7.x was EOLed in 2013