### PR TITLE
Disable check-local since most routes will not lead to existing files

### DIFF
--- a/Lighttpd.rst
+++ b/Lighttpd.rst
@@ -15,7 +15,7 @@ Modify your lighttpd.conf configuration file:
   server.modules += ( "mod_scgi" )
   scgi.protocol = "uwsgi"
   scgi.server = (
-    "/" => (( "host" => "127.0.0.1", "port" => 3031 )),
+    "/" => (( "host" => "127.0.0.1", "port" => 3031, "check-local" => "disable" )),
   )
 
 Further doc on configuring lighttpd and Python WSGI can be found at


### PR DESCRIPTION
In most Python apps you'll usually make pretty routes like /users/Cheaterman/profile or something, and these usually don't lead to existing files on the filesystem, which makes lighttpd send a 404 by default. This option prevents that behavior, and should usually be used for a "minimal" uWSGI deployment.