### PR TITLE
Added uwsgi::opt access example to PSGI Quickstart guide

### DIFF
--- a/PSGIquickstart.rst
+++ b/PSGIquickstart.rst
@@ -239,7 +239,7 @@ You can even pipe configs (using the dash to force reading from stdin):
    perl myjsonconfig_generator.pl | uwsgi --json -
 
 Accessing uWSGI options within application code
-******************
+***********************************************
 
 uWSGI options can be accessed within application code via ``uwsgi::opt``.
 

--- a/PSGIquickstart.rst
+++ b/PSGIquickstart.rst
@@ -238,6 +238,15 @@ You can even pipe configs (using the dash to force reading from stdin):
 
    perl myjsonconfig_generator.pl | uwsgi --json -
 
+Accessing uWSGI options within application code
+******************
+
+uWSGI options can be accessed within application code via ``uwsgi::opt``.
+
+.. code-block:: pl
+
+   my $uwsgi_opt = uwsgi::opt;
+   print $uwsgi_opt->{'http'};
 
 Automatically starting uWSGI on boot
 ************************************


### PR DESCRIPTION
Added a simple example to PSGI Quickstart to show how to access uWSGI options within perl application code. The current uWSGI Configuration documentation explains how to use ``uwsgi.opt`` in python, but does not mention the perl equivalent ``uwsgi::opt``. 

``uwsgi::opt`` for perl was added in https://github.com/unbit/uwsgi/commit/b59294db89c477d04624fa344c8b9b15435bebd0
