### PR TITLE
Add backquotes around attach-daemon2 heading

### DIFF
--- a/AttachingDaemons.rst
+++ b/AttachingDaemons.rst
@@ -136,7 +136,7 @@ Managing **celery beat**:
    legion-smart-attach-daemon = mylegion /tmp/celery-beat.pid celery beat --pidfile=/tmp/celery-beat.pid
    
    
---attach-daemon2
+``--attach-daemon2``
 ****************
 
 This option has been added in uWSGI 2.0 and allows advanced configurations. It is a keyval option, and it accepts the following keys:


### PR DESCRIPTION
Currently, Sphinx converts the two dashes in this heading to one longer one (see http://uwsgi-docs.readthedocs.io/en/latest/AttachingDaemons.html#attach-daemon2). I've added backquotes around the heading so that it (hopefully) doesn't perform this conversion, as those backquotes indicate that it's a code sample.