### PR TITLE
Nginx docs say if is evil

### DIFF
--- a/Nginx.rst
+++ b/Nginx.rst
@@ -194,8 +194,12 @@ For example, the Django ``/media`` path could be mapped like this::
 
 Some applications need to pass control to the UWSGI server only if the requested filename does not exist::
 
-  if (!-f $request_filename) {
+  location @process_in_app {
     uwsgi_pass uwsgicluster;
+  }
+  
+  location /on-the-fly {
+    try_files $uri $uri/ @process_in_app;
   }
 
 


### PR DESCRIPTION
It surprised me to even find they have [a whole page](https://www.nginx.com/resources/wiki/start/topics/depth/ifisevil/) talking about it. Should we recommend [try_files](https://www.nginx.com/resources/wiki/start/topics/tutorials/config_pitfalls/#check-if-file-exists) instead?