### PR TITLE
Chain reloading does not require lazy-apps

### DIFF
--- a/articles/TheArtOfGracefulReloading.rst
+++ b/articles/TheArtOfGracefulReloading.rst
@@ -252,8 +252,6 @@ Cons:
 Chain reloading (lazy apps)
 ***************************
 
-Requires ``--lazy-apps`` option.
-
 To trigger it:
 
 * write ``c`` to :doc:`../MasterFIFO`


### PR DESCRIPTION
I think the documentation is incorrect because we do not have lazy apps enabled and we are able to start a chain reload with the master FIFO.