### PR TITLE
Add -p option to mkdir

### DIFF
--- a/tutorials/Django_and_nginx.rst
+++ b/tutorials/Django_and_nginx.rst
@@ -467,8 +467,7 @@ vassal.
 .. code-block:: bash
 
     # create a directory for the vassals
-    sudo mkdir /etc/uwsgi
-    sudo mkdir /etc/uwsgi/vassals
+    sudo mkdir -p /etc/uwsgi/vassals
     # symlink from the default config directory to your config file
     sudo ln -s /path/to/your/mysite/mysite_uwsgi.ini /etc/uwsgi/vassals/
     # run the emperor


### PR DESCRIPTION
The `mkdir` command offers the -p option:

```
       -p, --parents
              no error if existing, make parent directories as needed
```

This can be used in this case rather than having two separate mkdir's.