### PR TITLE
Fix tutorial ini file

### DIFF
--- a/tutorials/Django_and_nginx.rst
+++ b/tutorials/Django_and_nginx.rst
@@ -402,7 +402,7 @@ Create a file called ```mysite_uwsgi.ini```::
     # the base directory (full path)
     chdir           = /path/to/your/project 
     # Django's wsgi file
-    module          = project.wsgi
+    module          = mysite.wsgi
     # the virtualenv (full path) 
     home            = /path/to/virtualenv
 


### PR DESCRIPTION
Going through the tutorial, the project is called `mysite`. This fix fixes the example ini file to properly reference the file the user has created.

There is no `project.wsgi` module when the user going through the tutorial.

Later in the ini file `mysite.sock` is referenced, so this matches that.