### PR TITLE
Fix directory location of mysite_nginx.conf

### DIFF
--- a/tutorials/Django_and_nginx.rst
+++ b/tutorials/Django_and_nginx.rst
@@ -214,7 +214,7 @@ https://github.com/nginx/nginx/blob/master/conf/uwsgi_params
 Copy it into your project directory. In a moment we will tell nginx to refer to
 it.
 
-Now create a file called mysite_nginx.conf in the /etc/nginx/sites-available/ directory, and put this in it::
+Now create a file called mysite_nginx.conf in your project directory, and put this in it::
 
     # mysite_nginx.conf
 

--- a/tutorials/Django_and_nginx.rst
+++ b/tutorials/Django_and_nginx.rst
@@ -211,10 +211,13 @@ You will need the ``uwsgi_params`` file, which is available in the ``nginx``
 directory of the uWSGI distribution, or from
 https://github.com/nginx/nginx/blob/master/conf/uwsgi_params
 
-Copy it into your project directory. In a moment we will tell nginx to refer to
+On debian based distributions (at least) the ``uwsgi_params`` file is already
+included so there's no need to use the
+project one, otherwise
+copy it into your project directory. In a moment we will tell nginx to refer to
 it.
 
-Now create a file called mysite_nginx.conf in your project directory, and put this in it::
+Now create a file called mysite_nginx.conf in the /etc/nginx/sites-available/  directory, and put this in it::
 
     # mysite_nginx.conf
 


### PR DESCRIPTION
In the [Configure nginx for your site](https://uwsgi-docs.readthedocs.io/en/latest/tutorials/Django_and_nginx.html#configure-nginx-for-your-site) section, the file `mysite_nginx.conf` should be created in the project directory, not in `/etc/nginx/sites-available/`. The `/etc/nginx/sites-available/` directory will contain a symlink to it.