### PR TITLE
max-requests-delta has not implemented yet

### DIFF
--- a/Options.rst
+++ b/Options.rst
@@ -2171,16 +2171,6 @@ max-requests
 
 
 
-max-requests-delta
-******************
-``argument``: required_argument
-
-``parser``: uwsgi_opt_set_64bit
-
-``help``: add (worker_id * delta) to the max_requests value of each worker
-
-
-
 min-worker-lifetime
 *******************
 ``argument``: required_argument


### PR DESCRIPTION
max-requests-delta seems not to be implemented on the latest release (2.0.18). I can not find max-requests-delta options on [uwsgi/core/uwsgi.c](https://github.com/unbit/uwsgi/blob/2.0.18/core/uwsgi.c)
If you configure max-requests-delta option on the latest release, it does not work without any warning.
It should be removed on the documents or add some notes to warn it does not work.