### PR TITLE
Example how to limit network interface listening

### DIFF
--- a/ThingsToKnow.rst
+++ b/ThingsToKnow.rst
@@ -1,7 +1,7 @@
 Things to know (best practices and "issues") READ IT !!!
 ========================================================
 
-* Obviously, never expose a socket speaking the uwsgi protocol to the public network unless you know what you are doing. That channel allows for dynamic loading of applications (read: arbitrary execution of code). The protocol is meant to be sanitized/validated by a proxy like nginx, apache, the uWSGI routers...
+* Obviously, never expose a socket speaking the uwsgi protocol to the public network unless you know what you are doing. That channel allows for dynamic loading of applications (read: arbitrary execution of code). The protocol is meant to be sanitized/validated by a proxy like nginx, apache, the uWSGI routers, etc. For example, if uwsgi uses ``--socket :1234`` parameter, it listens to port 1234 on every network interfaces. It can be limited to loopback interface with ``--socket localhost:1234`` parameter.
 
 * The ``http`` and ``http-socket`` options are entirely different beasts.
   The first one spawns an additional process forwarding requests to a series of workers (think about it as a form of shield, at the same level of apache or nginx), while the second one sets workers to natively speak the http protocol.


### PR DESCRIPTION
Providing an example should help to avoid or fix misconfiguration.

I wonder if it would be good to change each example with `:port` by `interface:port`.