### PR TITLE
Fix uWSGI version in http11-socket description

### DIFF
--- a/HTTP.rst
+++ b/HTTP.rst
@@ -94,7 +94,7 @@ If your backends set the correct HTTP headers, you can use the
 Also remember to set "Connection: Keep-Alive" in your response. You can
 automate that using the ``add-header = Connection: Keep-Alive`` option.
 
-Since uWSGI 2.1 (master branch) you can use the ``http11-socket`` option.
+Since uWSGI 2.0.16 you can use the ``http11-socket`` option.
 ``http11-socket`` may replace the ``add-header`` and ``http-keepalive`` options
 (but it doesn't touch tcp stuff as ``so-keepalive`` does).
 Once set the server will try to maintain the connection opened if a bunch of


### PR DESCRIPTION
Hi, I noticed that `http11-socket` description is slightly outdated. It was back-ported in [uWSGI 2.0.16](https://uwsgi-docs.readthedocs.io/en/latest/Changelog-2.0.16.html):

> Back-ported HTTP/1.1 support (–http11-socket) from 2.1