### PR TITLE
Typo fixed in the docs

### DIFF
--- a/AttachingDaemons.rst
+++ b/AttachingDaemons.rst
@@ -114,7 +114,7 @@ the namespace.
 Legion support
 **************
 
-Starting with uWSGI 1.9.9 it's possible to use the :doc:`Legion` subsystem for
+Starting with uWSGI 1.9.9 it's possible to use the :doc:`Legion` for
 daemon management.  Legion daemons will be executed only on the legion
 lord node, so there will always be a single daemon instance running in each
 legion. Once the lord dies a daemon will be spawned on another node.  To add a


### PR DESCRIPTION
It was like this before:
<img width="673" alt="Снимок экрана 2020-12-19 в 21 17 50" src="https://user-images.githubusercontent.com/4660275/102696485-c4f9a500-423f-11eb-8b1f-eaba4447f783.png">
