### PR TITLE
Add max-worker-lifetime-delta to docs

### DIFF
--- a/Options.rst
+++ b/Options.rst
@@ -2201,6 +2201,16 @@ max-worker-lifetime
 
 
 
+max-worker-lifetime-delta
+*******************
+``argument``: required_argument
+
+``parser``: uwsgi_opt_set_64bit
+
+``help``: add (worker_id * delta) to the max_worker_lifetime value of each worker
+
+
+
 socket-timeout
 **************
 ``argument``: required_argument


### PR DESCRIPTION
I found max-worker-lifetime-delta had been added, but found no trace of it in the Options.rst

* https://github.com/unbit/uwsgi/pull/2021/files
* https://github.com/unbit/uwsgi/issues/2020
* https://github.com/unbit/uwsgi/blob/master/core/master_checks.c
* https://github.com/unbit/uwsgi/blob/master/core/uwsgi.c