### PR TITLE
systemd: remove outdated config for syslog

### DIFF
--- a/Systemd.rst
+++ b/Systemd.rst
@@ -23,7 +23,6 @@ Create a systemd service file (you can save it as /etc/systemd/system/emperor.uw
 
    [Unit]
    Description=uWSGI Emperor
-   After=syslog.target
 
    [Service]
    ExecStart=/root/uwsgi/uwsgi --ini /etc/uwsgi/emperor.ini
@@ -174,7 +173,6 @@ app will run under its own user.
 
   [Unit]
   Description=%i uWSGI app
-  After=syslog.target
 
   [Service]
   ExecStart=/usr/bin/uwsgi \

--- a/Systemd.rst
+++ b/Systemd.rst
@@ -32,7 +32,7 @@ Create a systemd service file (you can save it as /etc/systemd/system/emperor.uw
    Restart=always
    KillSignal=SIGQUIT
    Type=notify
-   StandardError=syslog
+   StandardError=journal
    NotifyAccess=all
 
    [Install]
@@ -87,7 +87,7 @@ If you want to allow each vassal to run under different privileges, remove the `
 Logging
 *******
 
-Using the previous service file all of the Emperor messages go to the syslog. You can avoid it by removing the ``StandardError=syslog`` directive.
+Using the previous service file all of the Emperor messages go to the journal. You can avoid it by removing the ``StandardError=journal`` directive.
 
 If you do that, be sure to set a ``--logto`` option in your Emperor configuration, otherwise all of your logs will be lost!
 
@@ -185,7 +185,7 @@ app will run under its own user.
   Restart=on-failure
   KillSignal=SIGQUIT
   Type=notify
-  StandardError=syslog
+  StandardError=journal
   NotifyAccess=all
 
 Now, adding a new app to your system is a matter of creating the appropriate


### PR DESCRIPTION
See the reasoning in the commit messages.

I'm not entirely sure how the Linux distribution landscape handles the deprecation of syslog, but at least upstream systemd is quite clear in that regard.