### PR TITLE
Explain the meaning of "log-big"

### DIFF
--- a/Options.rst
+++ b/Options.rst
@@ -6337,7 +6337,7 @@ log-big
 
 ``parser``: uwsgi_opt_set_64bit
 
-``help``: log requestes bigger than the specified size
+``help``: log requestes whose response sizes are bigger than the specified size
 
 
 


### PR DESCRIPTION
The previous explanation of "log-big" is misleading, the argument refers the size of response, not the request.