### PR TITLE
Clarify mule behavior under lazy-apps

### DIFF
--- a/Mules.rst
+++ b/Mules.rst
@@ -12,7 +12,7 @@ Mules have two modes,
 * Signal only mode (the default). In this mode the mules load your application as normal workers would. They can only respond to :doc:`uWSGI signals<Signals>`.
 * Programmed mode. In this mode mules load a program separate from your application. See ProgrammedMules_.
 
-By default each mule starts in signal-only mode. 
+By default each mule starts in signal-only mode.
 
 .. code-block:: sh
 
@@ -35,22 +35,22 @@ Basic usage
 
     import uwsgi
     from uwsgidecorators import timer, signal, filemon
-    
+
     # run a timer in the first available mule
     @timer(30, target='mule')
     def hello(signum):
         print "Hi! I am responding to signal %d, running on mule %d" % (signum, uwsgi.mule_id())
-    
+
     # map signal 17 to mule 2
     @signal(17, target='mule2')
     def i_am_mule2(signum):
         print "Greetings! I am running in mule number two."
-    
+
     # monitor /tmp and arouse all of the mules on modifications
     @filemon('/tmp', target='mules')
     def tmp_modified(signum):
         print "/tmp has been modified. I am mule %d!" % uwsgi.mule_id()
-    
+
 
 .. _ProgrammedMules:
 
@@ -59,6 +59,8 @@ Giving a brain to mules
 
 As mentioned before, mules can be programmed. To give custom logic to a mule, give the ``mule`` option a path to
 a script (it must end in ".py") or a "package.module:callable" value.
+
+.. note:: When using with ``lazy-apps` callable is not supported. You must use a script path.
 
 .. code-block:: sh
 
@@ -71,23 +73,23 @@ This will run 4 mules, 2 in signal-only mode, one running :file:`somaro.py` and 
     # somaro.py
     from threading import Thread
     import time
-    
+
     def loop1():
         while True:
             print "loop1: Waiting for messages... yawn."
             message = uwsgi.mule_get_msg()
             print message
-    
+
     def loop2():
         print "Hi! I am loop2."
         while True:
             time.sleep(2)
             print "This is a thread!"
-    
+
     t = Thread(target=loop2)
     t.daemon = True
     t.start()
-    
+
     if __name__ == '__main__':
         loop1()
 


### PR DESCRIPTION
When lazy-apps is used the mules cannot be invoked as python callables. The script path must be used instead.

This patch just annotates the documentation to add that note.