### PR TITLE
Add a paragraph to explain the reason of the message "unable to load configuration from..."

### DIFF
--- a/Configuration.rst
+++ b/Configuration.rst
@@ -38,6 +38,13 @@ uWSGI supports loading configuration files over several methods other than simpl
 
 .. note::
 
+  If the configuration file type is not specified in the parameter list (e.g. --ini, --xml, etc.),
+  uwsgi tries to deduce the file type from the filename extension.
+  If the extension is not a supported file type,
+  uwsgi displays the message "unable to load configuration from..." and exits.
+
+.. note::
+
   More esoteric file sources, such as the :doc:`Emperor<Emperor>`, embedded
   configuration (in two flavors), dynamic library symbols and ELF sections
   could also be used.


### PR DESCRIPTION
I met the problem that `uwsgi foo.conf` outputs the message "unable to load configuration from..." and exits, leaving me absolutely no clue why, until I found the answer from [https://github.com/unbit/uwsgi-docs/issues/294](https://github.com/unbit/uwsgi-docs/issues/294) after an hour long search. So as it suggests, I  add  a note in section https://uwsgi-docs.readthedocs.org/en/latest/Configuration.html#loading-configuration-files that explains the reason of the message "unable to load configuration from..."