### PR TITLE
Fixed wrong flag name in Changelog-2.0.22.rst

### DIFF
--- a/Changelog-2.0.22.rst
+++ b/Changelog-2.0.22.rst
@@ -13,7 +13,7 @@ Changes
 
   - `harakiri-graceful-timeout` to control the timeout for the worker to attempt a graceful shutdown
   - `harakiri-graceful-signal`, to choose which signal to use for graceful harakiri (default: SIGTERM)
-  - `harakiri-graceful-queue-threshold` in order to trigger harakiri only when the listen queue crosses a threshold
+  - `harakiri-queue-threshold` in order to trigger harakiri only when the listen queue crosses a threshold
 - plugins/php: Fix PHP 8.2 compilation (Alexandre Rossi)
 - plugins/python: Use "backslashreplace" on stderr initialization (Nicolas Evrard)
 - Fix typo (Young Ziyi)


### PR DESCRIPTION
Fixed the wrong flag name for `harakiri-queue-threshold`. In the code is `harakiri_queue_threshold` and not `harakiri_graceful_queue_threshold`. See the line https://github.com/unbit/uwsgi/pull/2311/files#diff-20bb49c096a9dfc58fe610ef1482e0e604e5d3ecfd4785fe9fec217e6e8e0ed9R86