### PR TITLE
Systemd.rst: Remove syslog.target and an old note

### DIFF
--- a/Systemd.rst
+++ b/Systemd.rst
@@ -23,11 +23,9 @@ Create a systemd service file (you can save it as /etc/systemd/system/emperor.uw
 
    [Unit]
    Description=uWSGI Emperor
-   After=syslog.target
 
    [Service]
    ExecStart=/root/uwsgi/uwsgi --ini /etc/uwsgi/emperor.ini
-   # Requires systemd version 211 or newer
    RuntimeDirectory=uwsgi
    Restart=always
    KillSignal=SIGQUIT
@@ -174,7 +172,6 @@ app will run under its own user.
 
   [Unit]
   Description=%i uWSGI app
-  After=syslog.target
 
   [Service]
   ExecStart=/usr/bin/uwsgi \


### PR DESCRIPTION
syslog.target hasn't existed for over a decade, and note about requiring 2011+ version of systemd doesn't seem relevant today.

https://github.com/systemd/systemd/blob/6aa8d43ade72e24c9426e604f7fc4b7582b9db7c/NEWS#L72-L73