### PR TITLE
updated wget to get the latest tag tarball

### DIFF
--- a/WSGIquickstart.rst
+++ b/WSGIquickstart.rst
@@ -39,8 +39,8 @@ You have various ways to install uWSGI for Python:
 
   .. code-block:: sh
 
-      wget https://projects.unbit.it/downloads/uwsgi-latest.tar.gz
-      tar zxvf uwsgi-latest.tar.gz
+      wget https://github.com/unbit/uwsgi/archive/refs/tags/$(git ls-remote --tags --sort=v:refname https://github.com/unbit/uwsgi | cut -d/ -f3 | tail -n2 | head -n1).tar.gz
+      tar zxvf latest.tar.gz
       cd <dir>
       make
 


### PR DESCRIPTION
The current wget command downloads a prefixed tarball hosted at projects.unbit.it/downloads that is outdated, and causes problems. Instead of removing the whole thing, this updated command downloads the latest tag tarball.